### PR TITLE
Allows params for get requests

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -120,11 +120,16 @@ class Service {
 
   _get (id, params = {}) {
     params.query = params.query || {};
+    const query = Object.assign({}, filter(params.query || {}).query);
+
+    if (id !== null) {
+      query[this.id] = id;
+    }
 
     const discriminator = (params.query || {})[this.discriminatorKey] || this.discriminatorKey;
     const model = this.discriminators[discriminator] || this.Model;
     let modelQuery = model
-      .findOne({ [this.id]: id });
+      .findOne(query);
 
     // Handle $populate
     if (params.query.$populate) {
@@ -149,7 +154,8 @@ class Service {
       .exec()
       .then(data => {
         if (!data) {
-          throw new errors.NotFound(`No record found for id '${id}'`);
+          const msg = query[this.id] ? `No record found for id '${query[this.id]}'` : 'No record found';
+          throw new errors.NotFound(msg);
         }
 
         return data;


### PR DESCRIPTION
Useful if you have user roles and need to restrict the query to a subset of valid requests based on those roles.

For example, if `moderator` has access to everyone except `admin`s, a get request could be made:

/user/[admin id]

and you would need to write a hook that modifies params.query which excludes admins from users that get request is allowed to return.